### PR TITLE
feat: add mockDataModel to ProjectConfig type

### DIFF
--- a/packages/jest/src/config.d.ts
+++ b/packages/jest/src/config.d.ts
@@ -209,6 +209,7 @@ export type ProjectConfig = {
 	filter?: Path;
 	id: string;
 	injectGlobals: boolean;
+	mockDataModel: boolean;
 	resetMocks: boolean;
 	resetModules: boolean;
 	restoreMocks: boolean;


### PR DESCRIPTION
Adds missing `mockDataModel` type definition to ProjectConfig.

This enables TypeScript support for jest-roblox's DataModel mocking feature, which allows `jest.spyOn()` on Roblox instances when enabled.
